### PR TITLE
Add environment configurable port and upload dir

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+UPLOAD_DIR=uploads

--- a/README.md
+++ b/README.md
@@ -11,10 +11,23 @@ npm install
 npm start
 ```
 
-By default the server listens on port 3000.
+By default the server listens on port `3000`. You can override this by setting
+the `PORT` environment variable. The directory where uploaded files are stored
+can also be configured via the `UPLOAD_DIR` environment variable; it defaults to
+`uploads` inside the project root.
+
+## Configuration
+
+Copy `.env.example` to `.env` and adjust the values if you need to change the
+server port or upload directory:
+
+```bash
+cp .env.example .env
+# edit .env as needed
+```
 
 ## Uploads
 
-Uploaded files sent to `/upload` are saved inside the `uploads` directory at the project root. The server exposes this folder at `/uploads` so files can be accessed and listed via `/files`.
+Uploaded files sent to `/upload` are saved inside the directory specified by `UPLOAD_DIR` (default is `uploads` in the project root). The server exposes this folder at `/uploads` so files can be accessed and listed via `/files`.
 
 All HTML, CSS and client-side JavaScript files reside in the `public` directory which Express serves automatically.

--- a/server.js
+++ b/server.js
@@ -5,9 +5,11 @@ const multer = require('multer');
 
 const app = express();
 
-const uploadDir = path.join(__dirname, 'uploads');
+const uploadDir = process.env.UPLOAD_DIR
+  ? path.resolve(process.env.UPLOAD_DIR)
+  : path.join(__dirname, 'uploads');
 if (!fs.existsSync(uploadDir)) {
-  fs.mkdirSync(uploadDir);
+  fs.mkdirSync(uploadDir, { recursive: true });
 }
 
 const storage = multer.diskStorage({
@@ -51,7 +53,7 @@ app.get('/files', (req, res) => {
   });
 });
 
-const PORT = process.env.PORT || 3015;
+const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- let server port and uploads directory be configured via env vars
- document configuration options in README
- provide `.env.example` as a template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a8687b14c832d985b55b122cf660b