### PR TITLE
Improve file display layout

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -129,6 +129,7 @@ footer {
 
 body {
   background: #eef2f7;
+  font-family: Arial, Helvetica, sans-serif;
 }
 .imgJ {
   padding: 0;
@@ -167,3 +168,33 @@ body {
   background: red;
   color: white;
 }
+
+.file-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.file-tabs li {
+  flex: 1 0 calc(33.333% - 10px);
+  margin: 5px;
+}
+
+.file-tab-link {
+  display: block;
+  background: #17a2b8;
+  color: #fff;
+  padding: 10px;
+  border-radius: 4px;
+  text-align: center;
+  text-decoration: none;
+}
+
+.file-tab-link:hover {
+  background: #138496;
+  color: #fff;
+  text-decoration: none;
+}
+

--- a/views/resources.ejs
+++ b/views/resources.ejs
@@ -13,9 +13,10 @@
             <input type="file" name="file" required>
             <button type="submit">Upload</button>
           </form>
-          <ul id="files">
-            <% files.forEach(function(f){ %>
-              <li><a href="/uploads/<%= encodeURIComponent(f) %>"><%= f %></a></li>
+          <ul id="files" class="file-tabs">
+            <% files.forEach(function(f){
+                 const name = f.replace(/^\d+_/, '').replace(/cheat\s*sheet/ig, '').trim(); %>
+              <li><a class="file-tab-link" href="/uploads/<%= encodeURIComponent(f) %>"><%= name %></a></li>
             <% }) %>
           </ul>
         </section>
@@ -25,6 +26,10 @@
   </div>
 </section>
 <script>
+function cleanName(name){
+ return name.replace(/^\d+_/, '').replace(/cheat\s*sheet/ig, '').trim();
+}
+
 function loadFiles(){
  fetch("/files").then(r=>r.json()).then(files=>{
    const list=document.getElementById("files");
@@ -33,7 +38,8 @@ function loadFiles(){
      const li=document.createElement("li");
      const a=document.createElement("a");
      a.href="/uploads/"+encodeURIComponent(f);
-     a.textContent=f;
+     a.textContent=cleanName(f);
+     a.className="file-tab-link";
      li.appendChild(a);
      list.appendChild(li);
    });


### PR DESCRIPTION
## Summary
- style the resources page file list as colorful tabs
- strip upload timestamp and the text "cheat sheet" from displayed file names
- use Arial fonts and general enhancements

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ae9f8d3c8832db8252ab2b3707241