### PR TITLE
Add DQ Tracker link to main page tiles

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -160,6 +160,18 @@
           <a href="https://climat-bg.com" target="_blank" class="btn btn-sm btn-primary mt-2">Visit Site</a>
         </div>
       </div>
+
+      <!-- DQ Tracker -->
+      <div class="col-md-6 col-lg-4 mb-4">
+        <div class="service-card service-card-highlight">
+          <div class="service-icon">
+            <i class="fas fa-chart-line"></i>
+          </div>
+          <h3>DQ Tracker</h3>
+          <p>Track and monitor your data quality metrics with our easy-to-use dashboard.</p>
+          <a href="https://synaptiq42.com/dq-tracker/index.html" target="_blank" class="btn btn-sm btn-primary mt-2">Open Tracker</a>
+        </div>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Added a new tile for the DQ Tracker tool linking to https://synaptiq42.com/dq-tracker/index.html with a chart-line icon.